### PR TITLE
Fix CloudFront origin domain_name

### DIFF
--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -6,7 +6,7 @@ resource "aws_cloudfront_distribution" "static_site" {
   aliases = ["davidrstudios.com"]
 
   origin {
-    domain_name = aws_s3_bucket.static_site.bucket_regional_domain_name
+    domain_name = aws_s3_bucket_website_configuration.static_site.website_endpoint
     origin_id   = "s3-origin"
 
     custom_origin_config {


### PR DESCRIPTION
## Summary
- point CloudFront `static_site` origin to S3 website endpoint

## Testing
- `terraform fmt infra/*.tf`

------
https://chatgpt.com/codex/tasks/task_e_6882bf776a0c8320921225c20891fcd4